### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,3 +112,13 @@ These rules are mandatory and override any conflicting preference.
 - Single-purpose entry points: `main.ts`, `index.ts` when they only bootstrap or re-export.
 - Project-specific deploy/CI: `deploy-to-orderskew.ps1`, `run-dev.ps1`, `.github/workflows/novel-indicator-ci.yml`.
 - Legacy reference: `tools/novel_indicator/backend` (Python; not used at runtime).
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `npm install` in the JS/TS subprojects (`tools/novel_indicator/frontend`, `tools/novel_indicator/cloudflare_api`, `apps/worker`, `home-loan-archive`, `pages/domainname_wizard/source`) and installs Playwright chromium in `pages/domainname_wizard/source`. No root `npm install` is needed (root `package.json` has no dependencies).
+
+- **Run the core product locally**: it is a static site with no build step. Serve from repo root with `python3 -m http.server 8000`, then open `http://localhost:8000/index.html` (Trading Plan Calculator) or `http://localhost:8000/pages/index.html` (tools hub). See `README.md`.
+- **`npm run test:production:all` targets the LIVE `https://www.orderskew.com` by default**, not localhost. For local verification pass a local base URL and skip unreachable backends, e.g. `SKIP_NOVEL_API=1 node test-production-all.js http://localhost:8000`. It will still try Domain Name Wizard production sub-steps against the passed URL. Only expect a clean exit `0` against real production with deployed backends (per the Hard Enforcement Rules above).
+- **Playwright E2E runs headless** here; `node test-domainname-wizard.js` (unit + local static server + E2E) passes in this environment. Subproject unit tests: `cloudflare_api` and `apps/worker` use `npm test` (vitest); `home-loan-archive` uses the workers vitest pool.
+- **No lint step is configured** anywhere; TypeScript projects use `npm run typecheck` (or `npm run build`) as the closest check.
+- **Optional/uninstalled by default**: the BoardSpace Atlas RL Python backend (`tools/boardspace_atlas_rl`, FastAPI + heavy `torch`) and the legacy Python backend are not installed by the update script and are not required for the static products; install them manually only if working on that backend.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Order Skew monorepo, and documents non-obvious startup guidance for future cloud agents.

- Configured a startup update script that installs npm deps for the JS/TS subprojects (`tools/novel_indicator/frontend`, `tools/novel_indicator/cloudflare_api`, `apps/worker`, `home-loan-archive`, `pages/domainname_wizard/source`) and Playwright chromium.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` (only code change) covering how to serve the static core product, the local vs. production behavior of `test:production:all`, and which backends are optional.

## Verification

The core product (Trading Plan Calculator) was run and exercised end-to-end via a static server; a plan was configured and the charts/order tables rendered correctly.

[trading_plan_calculator_demo.mp4](https://cursor.com/agents/bc-90fa68f7-e531-4c02-b425-c1a12e7e64c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrading_plan_calculator_demo.mp4)

[Calculator results](https://cursor.com/agents/bc-90fa68f7-e531-4c02-b425-c1a12e7e64c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalculator_results.webp)

Checks run:
- Trading Plan Calculator + tools hub served via `python3 -m http.server 8000` (200 on all key pages).
- `npm run build` (novel_indicator frontend) — pass.
- `npm run typecheck` + `npm test` (novel_indicator cloudflare_api) — pass.
- `npm test` (domainname_wizard source, apps/worker, home-loan-archive) — pass.
- `node test-domainname-wizard.js` (unit + local static E2E via Playwright) — pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90fa68f7-e531-4c02-b425-c1a12e7e64c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90fa68f7-e531-4c02-b425-c1a12e7e64c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

