### PR TITLE
ci: auto-retry CodeRabbit review after rate limit

### DIFF
--- a/.github/workflows/pr-coderabbit-rate-limit-retry.yml
+++ b/.github/workflows/pr-coderabbit-rate-limit-retry.yml
@@ -1,0 +1,203 @@
+name: pr-coderabbit-rate-limit-retry
+
+# Portable / self-contained: no repo scripts required.
+# CodeRabbit does not auto-resume after rate limits. When it posts
+# "Review limit reached", wait for the stated window then @coderabbitai review.
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+      no_sleep:
+        description: Skip wait (test only)
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-coderabbit-rate-limit-retry-${{ github.event.issue.number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  retry-after-rate-limit:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event.issue.pull_request != null
+        && (
+          github.event.comment.user.login == 'coderabbitai[bot]'
+          || github.event.comment.user.login == 'coderabbitai'
+        )
+        && (
+          contains(github.event.comment.body, 'Review limit reached')
+          || contains(github.event.comment.body, 'rate limited by coderabbit.ai')
+          || contains(github.event.comment.body, 'reached your PR review limit')
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      - name: Wait for CodeRabbit quota then re-request review
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GATE_TOKEN || github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr_number }}
+          ISSUE_PR: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          NO_SLEEP: ${{ inputs.no_sleep }}
+          RETRY_MARKER: "<!-- simjury-coderabbit-rate-limit-retry -->"
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR="${INPUT_PR}"
+          else
+            PR="${ISSUE_PR}"
+          fi
+          if [ -z "${PR:-}" ] || [ "$PR" = "null" ]; then
+            echo "No PR number; skip"
+            exit 0
+          fi
+
+          STATE="$(gh pr view "$PR" --json state -q .state 2>/dev/null || true)"
+          if [ "${STATE}" != "OPEN" ]; then
+            echo "PR #$PR not open ($STATE); skip"
+            exit 0
+          fi
+
+          TITLE="$(gh pr view "$PR" --json title -q .title 2>/dev/null || true)"
+          case "$TITLE" in
+            chore:*|chore\(*|WIP*|wip*|"do not review"*)
+              echo "PR #$PR title looks chore/WIP ($TITLE); skip"
+              exit 0
+              ;;
+          esac
+
+          BODY="${COMMENT_BODY:-}"
+          CREATED="${COMMENT_CREATED_AT:-}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ -z "$BODY" ]; then
+            META="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+              --jq '[.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="coderabbitai")
+                and (.body|test("Review limit reached|rate limited by coderabbit|reached your PR review limit";"i")))]
+                | sort_by(.created_at) | reverse | .[0] // empty | {body, created_at}')"
+            if [ -z "$META" ] || [ "$META" = "null" ]; then
+              echo "No CodeRabbit rate-limit comment on PR #$PR; skip"
+              exit 0
+            fi
+            BODY="$(printf '%s' "$META" | jq -r .body)"
+            CREATED="$(printf '%s' "$META" | jq -r .created_at)"
+          fi
+
+          REVIEWED_AFTER="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews" --paginate \
+            --jq --arg after "$CREATED" '
+              [.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="coderabbitai")
+                and .submitted_at > $after
+                and (.state=="COMMENTED" or .state=="APPROVED" or .state=="CHANGES_REQUESTED")
+                and ((.body // "") | test("Review limit reached|rate limited by coderabbit";"i") | not))]
+              | length')"
+          if [ "${REVIEWED_AFTER:-0}" != "0" ]; then
+            echo "CodeRabbit already reviewed PR #$PR after rate-limit; skip"
+            exit 0
+          fi
+
+          ARMED="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+            --jq --arg after "$CREATED" --arg marker "$RETRY_MARKER" '
+              ( [.[] | select(.created_at > $after and (.body|contains($marker)) and (.body|test("@coderabbitai\\s+review";"i")))]
+                | map(.created_at) | max ) as $retry
+              | ( [.[] | select(.created_at > $after
+                    and (.user.login=="coderabbitai[bot]" or .user.login=="coderabbitai")
+                    and (.body|test("Review limit reached|rate limited by coderabbit";"i")))]
+                  | map(.created_at) | max ) as $newer
+              | if $retry == null then false
+                elif $newer != null and $newer > $retry then false
+                else true end')"
+          if [ "$ARMED" = "true" ]; then
+            echo "Retry already armed on PR #$PR; skip"
+            exit 0
+          fi
+
+          WAIT_MIN="$(BODY="$BODY" python3 - <<'PY'
+import os, re
+text = os.environ.get("BODY") or ""
+patterns = [
+    r"next review available in[:\s*]*\*?\*?(\d+)\s*minutes?",
+    r"more reviews will be available in\s+(\d+)\s*minutes?",
+    r"available in[:\s*]*\*?\*?(\d+)\s*minutes?",
+    r"next review available in[:\s*]*\*?\*?(\d+)\s*hours?",
+    r"more reviews will be available in\s+(\d+)\s*hours?",
+    r"available in[:\s*]*\*?\*?(\d+)\s*hours?",
+]
+for pat in patterns:
+    m = re.search(pat, text, re.I)
+    if not m:
+        continue
+    n = int(m.group(1))
+    if re.search(r"hours?", m.group(0), re.I) and not re.search(r"minutes?", m.group(0), re.I):
+        print(n * 60)
+    else:
+        print(n)
+    raise SystemExit
+print(60)
+PY
+)"
+
+          BUFFER_MIN=2
+          MAX_WAIT_MIN=120
+          SLEEP_SEC="$(CREATED="$CREATED" WAIT_MIN="$WAIT_MIN" BUFFER_MIN="$BUFFER_MIN" MAX_WAIT_MIN="$MAX_WAIT_MIN" python3 - <<'PY'
+import os, datetime
+created = os.environ["CREATED"]
+wait = int(os.environ["WAIT_MIN"])
+buf = int(os.environ["BUFFER_MIN"])
+max_wait = int(os.environ["MAX_WAIT_MIN"])
+ts = datetime.datetime.fromisoformat(created.replace("Z", "+00:00"))
+ready = ts + datetime.timedelta(minutes=wait + buf)
+now = datetime.datetime.now(datetime.timezone.utc)
+sec = max(0, int((ready - now).total_seconds()))
+print(min(sec, max_wait * 60))
+PY
+)"
+
+          echo "PR #$PR rate-limited at ${CREATED}; wait_min=${WAIT_MIN}; sleep_sec=${SLEEP_SEC}"
+          if [ "${NO_SLEEP:-false}" != "true" ] && [ "${SLEEP_SEC}" -gt 0 ]; then
+            LEFT="$SLEEP_SEC"
+            while [ "$LEFT" -gt 0 ]; do
+              STEP=$(( LEFT > 300 ? 300 : LEFT ))
+              sleep "$STEP"
+              LEFT=$(( LEFT - STEP ))
+              if [ "$LEFT" -gt 0 ]; then
+                echo "… ${LEFT}s remaining"
+              fi
+            done
+          fi
+
+          STATE="$(gh pr view "$PR" --json state -q .state 2>/dev/null || true)"
+          if [ "${STATE}" != "OPEN" ]; then
+            echo "PR #$PR closed during wait; skip"
+            exit 0
+          fi
+
+          REVIEWED_AFTER="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews" --paginate \
+            --jq --arg after "$CREATED" '
+              [.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="coderabbitai")
+                and .submitted_at > $after
+                and (.state=="COMMENTED" or .state=="APPROVED" or .state=="CHANGES_REQUESTED")
+                and ((.body // "") | test("Review limit reached|rate limited by coderabbit";"i") | not))]
+              | length')"
+          if [ "${REVIEWED_AFTER:-0}" != "0" ]; then
+            echo "CodeRabbit reviewed during wait; skip"
+            exit 0
+          fi
+
+          BODY_OUT="${RETRY_MARKER}"$'\n'"@coderabbitai review"
+          gh pr comment "$PR" --body "$BODY_OUT"
+          echo "Posted @coderabbitai review on PR #$PR"


### PR DESCRIPTION
## Summary

Adds portable `.github/workflows/pr-coderabbit-rate-limit-retry.yml`.
When CodeRabbit posts **Review limit reached**, waits for the stated window, then comments `@coderabbitai review`.

Self-contained (no repo scripts). Same workflow as simjury.

## Role

Engineer

## Summary by Sourcery

CI:
- Introduce a self-contained pr-coderabbit-rate-limit-retry workflow that waits for CodeRabbit rate-limit windows to elapse and then posts an @coderabbitai review comment on eligible pull requests.